### PR TITLE
fix code generation when phi has constant source

### DIFF
--- a/src/backend/riscv/function/basic_block.rs
+++ b/src/backend/riscv/function/basic_block.rs
@@ -1,5 +1,5 @@
 use super::{statement, FunctionCompileContext};
-use crate::ir;
+use crate::{backend::riscv::register_assign::RegisterAssign, ir};
 
 /// Emit assembly code for a [`ir::function::basic_block::BasicBlock`].
 pub fn emit_code(
@@ -11,9 +11,165 @@ pub fn emit_code(
     if let Some(name) = name {
         result.push_str(format!("{}:\n", name).as_str());
     }
-    for statement in content {
-        let statement_code = statement::emit_code(statement, ctx);
-        result.push_str(&statement_code);
+    if let Some((terminator, content)) = content.split_last() {
+        for statement in content {
+            let statement_code = statement::emit_code(statement, ctx);
+            result.push_str(&statement_code);
+        }
+        result.push_str(&append_phi_insert(ctx, basic_block));
+        let terminator_code = statement::emit_code(terminator, ctx);
+        result.push_str(&terminator_code);
+        result
+    } else {
+        String::new()
+    }
+}
+
+fn append_phi_insert(
+    ctx: &mut FunctionCompileContext,
+    basic_block: &ir::function::basic_block::BasicBlock,
+) -> String {
+    let mut result = String::new();
+    if let Some(phi_insert) = ctx
+        .phi_constant_assign
+        .get(basic_block.name.as_ref().unwrap())
+    {
+        for (register_assign, constant) in phi_insert {
+            match register_assign {
+                RegisterAssign::Register(register) => {
+                    result.push_str(format!("    li {}, {}\n", register, constant).as_str());
+                }
+                RegisterAssign::StackRef(offset) => {
+                    result.push_str(format!("    li t0, {}\n", constant).as_str());
+                    result.push_str(format!("    sw t0, {}(sp)\n", offset).as_str());
+                }
+                RegisterAssign::StackValue(offset) => {
+                    result.push_str(format!("    li t0, {}\n", constant).as_str());
+                    result.push_str(format!("    sw t0, {}(sp)\n", offset).as_str());
+                }
+                RegisterAssign::MultipleRegisters(_) => {
+                    unreachable!()
+                }
+            }
+        }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::borrow_interior_mutable_const)]
+
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::{
+        backend::riscv::{
+            function::FunctionCompileContext, register_assign::RegisterAssign, Context,
+        },
+        ir::{
+            self,
+            function::{basic_block::BasicBlock, test_util::*},
+            statement::{phi::PhiSource, Phi},
+            RegisterName,
+        },
+        utility::data_type::{self, Type},
+    };
+
+    #[test]
+    fn phi_insert() {
+        let function = ir::FunctionDefinition {
+            name: "f".to_string(),
+            parameters: Vec::new(),
+            return_type: Type::None,
+            content: vec![
+                BasicBlock {
+                    name: Some("f_entry".to_string()),
+                    content: vec![binop_constant("reg1"), branch("bb1", "bb2")],
+                },
+                BasicBlock {
+                    name: Some("bb1".to_string()),
+                    content: vec![binop_constant("reg2"), jump("bb3")],
+                },
+                BasicBlock {
+                    name: Some("bb2".to_string()),
+                    content: vec![binop_constant("reg3"), jump("bb3")],
+                },
+                BasicBlock {
+                    name: Some("bb3".to_string()),
+                    content: vec![Phi {
+                        to: RegisterName("reg0".to_string()),
+                        data_type: data_type::I32.clone(),
+                        from: vec![
+                            PhiSource {
+                                name: 1.into(),
+                                block: "bb1".to_string(),
+                            },
+                            PhiSource {
+                                name: 2.into(),
+                                block: "bb2".to_string(),
+                            },
+                        ],
+                    }
+                    .into()],
+                },
+            ],
+        };
+        let mut register_assign = HashMap::new();
+        register_assign.insert(
+            RegisterName("reg0".to_string()),
+            RegisterAssign::Register("t2".to_string()),
+        );
+        register_assign.insert(
+            RegisterName("reg1".to_string()),
+            RegisterAssign::Register("t3".to_string()),
+        );
+        register_assign.insert(
+            RegisterName("reg2".to_string()),
+            RegisterAssign::Register("t4".to_string()),
+        );
+        register_assign.insert(
+            RegisterName("reg3".to_string()),
+            RegisterAssign::Register("t5".to_string()),
+        );
+        let mut ctx = Context {
+            struct_definitions: HashMap::new(),
+        };
+        let mut context = FunctionCompileContext {
+            parent_context: &mut ctx,
+            local_assign: register_assign,
+            cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
+        };
+        context.phi_constant_assign.insert(
+            "bb1".to_string(),
+            vec![(RegisterAssign::Register("t2".to_string()), 1.into())],
+        );
+        context.phi_constant_assign.insert(
+            "bb2".to_string(),
+            vec![(RegisterAssign::Register("t2".to_string()), 2.into())],
+        );
+        let code = emit_code(&function.content[1], &mut context);
+        assert_eq!(
+            code,
+            r#"bb1:
+    li t0, 1
+    li t1, 2
+    add t4, t0, t1
+    li t2, 1
+    j bb3
+"#
+        );
+        let code = emit_code(&function.content[2], &mut context);
+        assert_eq!(
+            code,
+            r#"bb2:
+    li t0, 1
+    li t1, 2
+    add t5, t0, t1
+    li t2, 2
+    j bb3
+"#
+        )
+    }
 }

--- a/src/backend/riscv/function/mod.rs
+++ b/src/backend/riscv/function/mod.rs
@@ -4,6 +4,9 @@ use super::register_assign::{self, RegisterAssign};
 use crate::ir::{
     self,
     analyzer::{control_flow::ControlFlowGraph, register_usage::RegisterUsageAnalyzer},
+    quantity::Quantity,
+    statement::{IRStatement, Phi},
+    RegisterName,
 };
 
 pub mod basic_block;
@@ -18,6 +21,27 @@ pub struct FunctionCompileContext<'a> {
     /// Some times we need to do some cleanup before return (eg, pop the stack frame)
     /// So we can jump to this label instead of return directly.
     pub cleanup_label: Option<String>,
+    pub phi_constant_assign: HashMap<String, Vec<(RegisterAssign, i64)>>,
+}
+
+fn collect_phi_constant_assign(
+    function: &ir::FunctionDefinition,
+    register_assign: &HashMap<RegisterName, RegisterAssign>,
+) -> HashMap<String, Vec<(RegisterAssign, i64)>> {
+    let mut result: HashMap<String, Vec<(RegisterAssign, i64)>> = HashMap::new();
+    for statement in function.iter() {
+        if let IRStatement::Phi(Phi { to, from, .. }) = statement {
+            for from in from {
+                if let Quantity::NumberLiteral(n) = from.name {
+                    result
+                        .entry(from.block.clone())
+                        .or_default()
+                        .push((register_assign[to].clone(), n));
+                }
+            }
+        }
+    }
+    result
 }
 
 /// Emit assembly code for a [`ir::FunctionDefinition`].
@@ -26,6 +50,7 @@ pub fn emit_code(function: &ir::FunctionDefinition, ctx: &mut super::Context) ->
     let register_usage = RegisterUsageAnalyzer::new(function);
     let (register_assign, stack_space) =
         register_assign::assign_register(ctx, function, control_flow_graph, register_usage);
+    let phi_constant_assign = collect_phi_constant_assign(function, &register_assign);
     let mut result = format!("{}:\n", function.name);
     let mut context = FunctionCompileContext {
         parent_context: ctx,
@@ -35,6 +60,7 @@ pub fn emit_code(function: &ir::FunctionDefinition, ctx: &mut super::Context) ->
         } else {
             None
         },
+        phi_constant_assign,
     };
     if stack_space != 0 {
         result.push_str(format!("    addi sp, sp, -{}\n", stack_space).as_str());
@@ -50,4 +76,74 @@ pub fn emit_code(function: &ir::FunctionDefinition, ctx: &mut super::Context) ->
         result.push_str("    ret\n");
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::borrow_interior_mutable_const)]
+
+    use crate::{
+        ir::{
+            function::{basic_block::BasicBlock, test_util::*},
+            statement::phi::PhiSource,
+        },
+        utility::data_type::{self, Type},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_collect_phi_constant_assign() {
+        let function = ir::FunctionDefinition {
+            name: "f".to_string(),
+            parameters: Vec::new(),
+            return_type: Type::None,
+            content: vec![
+                BasicBlock {
+                    name: Some("f_entry".to_string()),
+                    content: vec![branch("bb1", "bb2")],
+                },
+                BasicBlock {
+                    name: Some("bb1".to_string()),
+                    content: vec![jump("bb3")],
+                },
+                BasicBlock {
+                    name: Some("bb2".to_string()),
+                    content: vec![jump("bb3")],
+                },
+                BasicBlock {
+                    name: Some("bb3".to_string()),
+                    content: vec![Phi {
+                        to: RegisterName("reg0".to_string()),
+                        data_type: data_type::I32.clone(),
+                        from: vec![
+                            PhiSource {
+                                name: 1.into(),
+                                block: "bb1".to_string(),
+                            },
+                            PhiSource {
+                                name: 2.into(),
+                                block: "bb2".to_string(),
+                            },
+                        ],
+                    }
+                    .into()],
+                },
+            ],
+        };
+        let mut register_assign = HashMap::new();
+        register_assign.insert(
+            RegisterName("reg0".to_string()),
+            RegisterAssign::Register("t0".to_string()),
+        );
+        let result = collect_phi_constant_assign(&function, &register_assign);
+        let bb1_result = result.get("bb1").unwrap();
+        assert_eq!(bb1_result.len(), 1);
+        assert_eq!(bb1_result[0].0, RegisterAssign::Register("t0".to_string()));
+        assert_eq!(bb1_result[0].1, 1);
+        let bb2_result = result.get("bb2").unwrap();
+        assert_eq!(bb2_result.len(), 1);
+        assert_eq!(bb2_result[0].0, RegisterAssign::Register("t0".to_string()));
+        assert_eq!(bb2_result[0].1, 2);
+    }
 }

--- a/src/backend/riscv/function/statement/load_field.rs
+++ b/src/backend/riscv/function/statement/load_field.rs
@@ -151,6 +151,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -242,6 +243,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),
@@ -285,6 +287,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),
@@ -331,6 +334,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -406,6 +410,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),
@@ -457,6 +462,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),
@@ -503,6 +509,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),

--- a/src/backend/riscv/function/statement/mod.rs
+++ b/src/backend/riscv/function/statement/mod.rs
@@ -23,7 +23,7 @@ pub fn emit_code(
     ctx: &mut FunctionCompileContext,
 ) -> String {
     match statement {
-        ir::statement::IRStatement::Phi(_) => todo!(),
+        ir::statement::IRStatement::Phi(_) => String::new(),
         ir::statement::IRStatement::Alloca(_) => String::new(),
         ir::statement::IRStatement::UnaryCalculate(unary_calculate) => {
             unary_calculate::emit_code(unary_calculate, ctx)

--- a/src/backend/riscv/function/statement/set_field.rs
+++ b/src/backend/riscv/function/statement/set_field.rs
@@ -424,6 +424,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -461,6 +462,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -502,6 +504,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),
@@ -558,6 +561,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -631,6 +635,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -693,6 +698,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         // Simple struct
         ctx.local_assign.insert(
@@ -745,6 +751,7 @@ mod tests {
             parent_context: &mut ctx,
             local_assign: HashMap::new(),
             cleanup_label: None,
+            phi_constant_assign: HashMap::new(),
         };
         ctx.local_assign.insert(
             RegisterName("a".to_string()),


### PR DESCRIPTION
<!--
下面的内容可以使用中文或者英文填写。
-->

<!--
You can fill the following things by using English or Chinese.
-->

### What problem does this PR solve?

Issue Number: close #25 

Problem Summary:
If a phi source is a constant, the backend won't generate correct code.

### What is changed and how it works?

What's Changed:

Let the source basic block take charge of storing the value into the assigned space for the `phi`ed ir register.
