### PR TITLE
show long version string when `--version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "come"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,6 +17,10 @@ nom = "7.1.1"
 paste = "1.0.10"
 petgraph = "0.6.2"
 phf = { version = "0.11.1", features = ["macros"] }
+shadow-rs = "0.20.0"
 
 [dev-dependencies]
 cov-mark = "1.1.0"
+
+[build-dependencies]
+shadow-rs = "0.20.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,13 @@ mod ir;
 /// Utilities shared among modules.
 mod utility;
 
+use shadow_rs::shadow;
+
+shadow!(build);
+
 /// Come language compiler.
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(version, long_version = build::CLAP_LONG_VERSION, about, long_about = None)]
 struct Args {
     /// Input file path.
     #[arg(short, long)]


### PR DESCRIPTION
<!--
下面的内容可以使用中文或者英文填写。
-->

<!--
You can fill the following things by using English or Chinese.
-->

### What problem does this PR solve?

Problem Summary:
Currently there's no way to know which commit the project is built from.

### What is changed and how it works?

What's Changed:
Display detailed build infomation with `shadow-rs`
